### PR TITLE
Remove the use of RegressionTestingAminoCodec in unit tests

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -41,6 +41,9 @@ const (
 // transaction-level processing (e.g. fee payment, signature verification) before
 // being passed onto it's respective handler.
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
+	if options.EncodingConfig.Amino == nil {
+		panic("amino codec not set in encoding config for ante handler")
+	}
 	if err := options.validate(); err != nil {
 		return nil, err
 	}

--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -1,6 +1,7 @@
 package ante_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -19,9 +20,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -33,8 +36,6 @@ import (
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 
 	amino "github.com/cosmos/cosmos-sdk/codec"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
 func TestAnteTestSuite(t *testing.T) {
@@ -57,10 +58,81 @@ func TestAnteTestSuite(t *testing.T) {
 	})
 }
 
+// func (suite AnteTestSuite) TestEncodingIssue() {
+// 	var acc sdk.AccountI
+// 	addr, privKey := tests.NewAddrKey()
+// 	to := tests.GenerateAddress()
+// 	to = to
+
+// 	setup := func() {
+// 		suite.enableFeemarket = false
+// 		suite.SetupTest() // reset
+
+// 		acc = suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, addr.Bytes())
+// 		suite.Require().NoError(acc.SetSequence(1))
+// 		suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
+
+// 		suite.app.EvmKeeper.SetBalance(suite.ctx, addr, big.NewInt(10000000000))
+
+// 		suite.app.FeeMarketKeeper.SetBaseFee(suite.ctx, big.NewInt(100))
+// 	}
+
+// 	testCases := []struct {
+// 		name      string
+// 		txFn      func() sdk.Tx
+// 		checkTx   bool
+// 		reCheckTx bool
+// 		expPass   bool
+// 	}{
+
+// 		{
+// 			"success - DeliverTx EIP712 signed Cosmos Tx with MsgSend",
+// 			func() sdk.Tx {
+// 				from := acc.GetAddress()
+// 				gas := uint64(200000)
+// 				amount := sdk.NewCoins(sdk.NewCoin(evmtypes.DefaultEVMDenom, sdkmath.NewInt(100*int64(gas))))
+// 				txBuilder := suite.CreateTestEIP712TxBuilderMsgSend(from, privKey, "ethermint_9000-1", gas, amount)
+// 				return txBuilder.GetTx()
+// 			}, false, false, true,
+// 		},
+// 	}
+
+// 	for _, tc := range testCases {
+// 		suite.Run(tc.name, func() {
+// 			setup()
+
+// 			tx := tc.txFn()
+// 			msgs := tx.GetMsgs()
+// 			cdc := suite.app.EncodingConfig.Amino
+// 			msgsBytes := make([]json.RawMessage, 0, len(msgs))
+// 			for _, msg := range msgs {
+// 				bz := cdc.MustMarshalJSON(msg)
+// 				msgsBytes = append(msgsBytes, mustSortJSON(bz))
+// 			}
+
+// 			fmt.Printf("Amino Msgs: %s\n", msgsBytes)
+// 		})
+// 	}
+// }
+
+func mustSortJSON(bz []byte) []byte {
+	var c any
+	err := json.Unmarshal(bz, &c)
+	if err != nil {
+		panic(err)
+	}
+	js, err := json.Marshal(c)
+	if err != nil {
+		panic(err)
+	}
+	return js
+}
+
 func (suite AnteTestSuite) TestAnteHandler() {
 	var acc sdk.AccountI
 	addr, privKey := tests.NewAddrKey()
 	to := tests.GenerateAddress()
+	to = to
 
 	setup := func() {
 		suite.enableFeemarket = false

--- a/app/ante/eip712.go
+++ b/app/ante/eip712.go
@@ -209,12 +209,26 @@ func (svd LegacyEip712SigVerificationDecorator) AnteHandle(ctx sdk.Context,
 	}
 
 	// Attempt to verify the signature against all EVM Chain IDs
+	var verifyErrors []error
+	var success bool
 	for _, evmChainID := range evmChainIds {
-		if err = VerifySignature(pubKey, signerData, sig.Data, svd.signModeHandler, authSignTx, evmChainID, svd.aminoCodec); err != nil {
+		if err := VerifySignature(pubKey, signerData, sig.Data, svd.signModeHandler, authSignTx, evmChainID, svd.aminoCodec); err != nil {
+			verifyErrors = append(verifyErrors, fmt.Errorf("evmChainID %s: %w", evmChainID, err))
+			fmt.Printf("\n\nFailed to verify EIP712 signature with evmChainID %s error: %v\n\n", evmChainID, err)
 			continue
 		} else {
+			success = true
 			break
 		}
+	}
+	// Note that we do not need to check the length of evmChainIDs here, it's already been done
+	if !success && len(verifyErrors) > 0 {
+		combinedErr := errorsmod.Wrapf(
+			errortypes.ErrUnauthorized,
+			"signature verification failed for all evmChainIDs; errors: %v",
+			verifyErrors,
+		)
+		return ctx, combinedErr
 	}
 
 	// If none succeeded, return an error

--- a/app/ante/eip712.go
+++ b/app/ante/eip712.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	errorsmod "cosmossdk.io/errors"
+	simappparams "cosmossdk.io/simapp/params"
 	txsigning "cosmossdk.io/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -68,7 +69,7 @@ func NewLegacyCosmosAnteHandlerEip712(options HandlerOptions) sdk.AnteHandler {
 		authante.NewValidateSigCountDecorator(options.AccountKeeper),
 		authante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		// Note: signature verification uses EIP instead of the cosmos signature validator
-		NewLegacyEip712SigVerificationDecorator(options.AccountKeeper, options.SignModeHandler, options.EvmChainIDs),
+		NewLegacyEip712SigVerificationDecorator(options.AccountKeeper, options.SignModeHandler, options.EvmChainIDs, options.EncodingConfig),
 		authante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
 		NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
@@ -85,6 +86,7 @@ type LegacyEip712SigVerificationDecorator struct {
 	ak              evmtypes.AccountKeeper
 	signModeHandler *txsigning.HandlerMap
 	evmChainIds     []string
+	aminoCodec      *codec.LegacyAmino
 }
 
 // Deprecated: NewLegacyEip712SigVerificationDecorator creates a new LegacyEip712SigVerificationDecorator
@@ -94,11 +96,13 @@ func NewLegacyEip712SigVerificationDecorator(
 	ak evmtypes.AccountKeeper,
 	signModeHandler *txsigning.HandlerMap,
 	evmChainIds []string,
+	encodingConfig simappparams.EncodingConfig,
 ) LegacyEip712SigVerificationDecorator {
 	return LegacyEip712SigVerificationDecorator{
 		ak:              ak,
 		signModeHandler: signModeHandler,
 		evmChainIds:     evmChainIds,
+		aminoCodec:      encodingConfig.Amino,
 	}
 }
 
@@ -206,7 +210,7 @@ func (svd LegacyEip712SigVerificationDecorator) AnteHandle(ctx sdk.Context,
 
 	// Attempt to verify the signature against all EVM Chain IDs
 	for _, evmChainID := range evmChainIds {
-		if err = VerifySignature(pubKey, signerData, sig.Data, svd.signModeHandler, authSignTx, evmChainID); err != nil {
+		if err = VerifySignature(pubKey, signerData, sig.Data, svd.signModeHandler, authSignTx, evmChainID, svd.aminoCodec); err != nil {
 			continue
 		} else {
 			break
@@ -233,7 +237,11 @@ func VerifySignature(
 	_ *txsigning.HandlerMap,
 	tx authsigning.Tx,
 	evmChainID string,
+	aminoCodec *codec.LegacyAmino,
 ) error {
+	if aminoCodec == nil {
+		panic("amino codec not set for EIP712 signature verification")
+	}
 	switch data := sigData.(type) {
 	case *signing.SingleSignatureData:
 		if data.SignMode != signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON {
@@ -253,7 +261,8 @@ func VerifySignature(
 			return errorsmod.Wrap(errortypes.ErrNoSignatures, "tx doesn't contain any msgs to verify signature")
 		}
 
-		txBytes := legacytx.StdSignBytes(
+		txBytes := eip712.LegacyStdSignBytes(
+			aminoCodec,
 			signerData.ChainID,
 			signerData.AccountNumber,
 			signerData.Sequence,

--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -17,6 +17,7 @@ package ante
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	simappparams "cosmossdk.io/simapp/params"
 	storetypes "cosmossdk.io/store/types"
 	txsigning "cosmossdk.io/x/tx/signing"
 
@@ -50,6 +51,7 @@ type HandlerOptions struct {
 	TxFeeChecker           ante.TxFeeChecker
 	DisabledAuthzMsgs      []string
 	EvmChainIDs            []string
+	EncodingConfig         simappparams.EncodingConfig
 }
 
 func (options HandlerOptions) validate() error {

--- a/app/ante/utils_test.go
+++ b/app/ante/utils_test.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	"github.com/cosmos/cosmos-sdk/x/staking"
@@ -154,7 +153,8 @@ func (suite *AnteTestSuite) SetupTest() {
 			sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
 			sdk.MsgTypeURL(&vestingtypes.MsgCreateVestingAccount{}),
 		},
-		EvmChainIDs: []string{"9000"},
+		EvmChainIDs:    []string{"9000"},
+		EncodingConfig: encodingConfig,
 	})
 	suite.Require().NoError(err)
 
@@ -175,8 +175,6 @@ func (suite *AnteTestSuite) SetupTest() {
 	suite.ctx = suite.ctx.WithBlockHeight(header.Height - 1)
 	suite.ctx, err = testutil.Commit(suite.ctx, suite.app, time.Second*0, nil)
 	suite.Require().NoError(err)
-
-	legacytx.RegressionTestingAminoCodec = encodingConfig.Amino
 }
 
 func (s *AnteTestSuite) BuildTestEthTx(

--- a/app/app.go
+++ b/app/app.go
@@ -782,7 +782,7 @@ func NewEthermintApp(
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetPreBlocker(app.PreBlocker)
 	app.SetEndBlocker(app.EndBlocker)
-	app.setAnteHandler(txConfig, cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted)))
+	app.setAnteHandler(encodingConfig, cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted)))
 
 	// In v0.46, the SDK introduces _postHandlers_. PostHandlers are like
 	// antehandlers, but are run _after_ the `runMsgs` execution. They are also
@@ -825,12 +825,12 @@ func NewEthermintApp(
 }
 
 // use Ethermint's custom AnteHandler
-func (app *EthermintApp) setAnteHandler(txConfig client.TxConfig, maxGasWanted uint64) {
+func (app *EthermintApp) setAnteHandler(encodingConfig simappparams.EncodingConfig, maxGasWanted uint64) {
 	anteHandler, err := ante.NewAnteHandler(
 		ante.HandlerOptions{
 			AccountKeeper:          app.AccountKeeper,
 			BankKeeper:             app.BankKeeper,
-			SignModeHandler:        txConfig.SignModeHandler(),
+			SignModeHandler:        encodingConfig.TxConfig.SignModeHandler(),
 			FeegrantKeeper:         app.FeeGrantKeeper,
 			SigGasConsumer:         ante.DefaultSigVerificationGasConsumer,
 			IBCKeeper:              app.IBCKeeper,
@@ -845,7 +845,8 @@ func (app *EthermintApp) setAnteHandler(txConfig client.TxConfig, maxGasWanted u
 				sdk.MsgTypeURL(&vestingtypes.MsgCreatePermanentLockedAccount{}),
 				sdk.MsgTypeURL(&vestingtypes.MsgCreatePeriodicVestingAccount{}),
 			},
-			EvmChainIDs: []string{"9000"},
+			EvmChainIDs:    []string{"9000"},
+			EncodingConfig: encodingConfig,
 		},
 	)
 	if err != nil {

--- a/ethereum/eip712/encoding.go
+++ b/ethereum/eip712/encoding.go
@@ -192,7 +192,8 @@ func decodeProtobufSignDoc(signDocBytes []byte) (apitypes.TypedData, error) {
 	}
 
 	// WrapTxToTypedData expects the payload as an Amino Sign Doc
-	signBytes := legacytx.StdSignBytes(
+	signBytes := LegacyStdSignBytes(
+		aminoCodec,
 		signDoc.ChainId,
 		signDoc.AccountNumber,
 		signerInfo.Sequence,

--- a/ethereum/eip712/encoding_legacy.go
+++ b/ethereum/eip712/encoding_legacy.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -197,7 +198,8 @@ func legacyDecodeProtobufSignDoc(signDocBytes []byte) (apitypes.TypedData, error
 	}
 
 	// WrapTxToTypedData expects the payload as an Amino Sign Doc
-	signBytes := legacytx.StdSignBytes(
+	signBytes := LegacyStdSignBytes(
+		aminoCodec,
 		signDoc.ChainId,
 		signDoc.AccountNumber,
 		signerInfo.Sequence,
@@ -281,4 +283,43 @@ func getMsgType(msg sdk.Msg) (string, error) {
 	}
 
 	return jsonMsg.Type, nil
+}
+
+// LegacyStdSignBytes returns the bytes to sign for a transaction.
+// Note that this function was deprecated, but in order to preserve eip712 signing we need to reproduce it here and remove the panic condition
+func LegacyStdSignBytes(cdc *codec.LegacyAmino, chainID string, accnum, sequence, timeout uint64, fee legacytx.StdFee, msgs []sdk.Msg, memo string) []byte {
+	amino := codec.NewLegacyAmino()
+	msgsBytes := make([]json.RawMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		bz := cdc.MustMarshalJSON(msg)
+		msgsBytes = append(msgsBytes, mustSortJSON(bz))
+	}
+
+	bz, err := amino.MarshalJSON(legacytx.StdSignDoc{
+		AccountNumber: accnum,
+		ChainID:       chainID,
+		Fee:           json.RawMessage(fee.Bytes()),
+		Memo:          memo,
+		Msgs:          msgsBytes,
+		Sequence:      sequence,
+		TimeoutHeight: timeout,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return mustSortJSON(bz)
+}
+
+func mustSortJSON(bz []byte) []byte {
+	var c any
+	err := json.Unmarshal(bz, &c)
+	if err != nil {
+		panic(err)
+	}
+	js, err := json.Marshal(c)
+	if err != nil {
+		panic(err)
+	}
+	return js
 }

--- a/testutil/tx/eip712.go
+++ b/testutil/tx/eip712.go
@@ -113,7 +113,7 @@ func PrepareEIP712CosmosTx(
 	fee := legacytx.NewStdFee(txArgs.Gas, txArgs.Fees) //nolint: staticcheck
 
 	msgs := txArgs.Msgs
-	data := legacytx.StdSignBytes(ctx.ChainID(), accNumber, nonce, 0, fee, msgs, "")
+	data := eip712.LegacyStdSignBytes(appEthermint.LegacyAmino(), ctx.ChainID(), accNumber, nonce, 0, fee, msgs, "")
 
 	typedDataArgs := typedDataArgs{
 		chainID:        chainIDNum,


### PR DESCRIPTION
Fixes the error "must set RegressionTestingAminoCodec before calling StdSignBytes" in unit tests